### PR TITLE
chore: update docker image in setup.sh

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -50,12 +50,12 @@ printf "\n${CYAN}Clean up complete.${PLAIN}\n"
 
 ## pull latest mssql image
 printf "\n${RED}>> Pulling latest mssql image${PLAIN} ${GREEN}...${PLAIN}"
-docker pull microsoft/mssql-server-linux:latest > /dev/null 2>&1
+docker pull mcr.microsoft.com/mssql/server:2019-latest > /dev/null 2>&1
 printf "\n${CYAN}Image successfully built.${PLAIN}\n"
 
 ## run the mssql container
 printf "\n${RED}>> Starting the mssql container${PLAIN} ${GREEN}...${PLAIN}"
-CONTAINER_STATUS=$(docker run --name $MSSQL_CONTAINER -e ACCEPT_EULA=Y -e SA_PASSWORD=$PASSWORD -p $PORT:1433 -d microsoft/mssql-server-linux:latest 2>&1)
+CONTAINER_STATUS=$(docker run --name $MSSQL_CONTAINER -e ACCEPT_EULA=Y -e SA_PASSWORD=$PASSWORD -p $PORT:1433 -d mcr.microsoft.com/mssql/server:2019-latest 2>&1)
 if [[ "$CONTAINER_STATUS" == *"Error"* ]]; then
     printf "\n\n${CYAN}Status: ${PLAIN}${RED}Error starting container. Terminating setup.${PLAIN}\n\n"
     exit 1


### PR DESCRIPTION
Signed-off-by: Diana Lau <dhmlau@ca.ibm.com>

When trying to set up the local environment to run the tests, I realized that the docker image specified in `setup.sh` no longer exist, it should be https://hub.docker.com/_/microsoft-mssql-server. 

cc @marioestradarosa 

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

- [x] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [x] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](https://loopback.io/doc/en/contrib/style-guide-es6.html)
- [x] Commit messages are following our [guidelines](https://loopback.io/doc/en/contrib/git-commit-messages.html)
